### PR TITLE
[EC2] [SPARK-6188] Instance types can be mislabeled when re-starting cluster with default arguments

### DIFF
--- a/ec2/spark_ec2.py
+++ b/ec2/spark_ec2.py
@@ -1259,6 +1259,15 @@ def real_main():
             cluster_instances=(master_nodes + slave_nodes),
             cluster_state='ssh-ready'
         )
+        
+        # Determine types of running instances
+        existing_master_type = master_nodes[0].instance_type
+        existing_slave_type = slave_nodes[0].instance_type
+        if existing_master_type == existing_slave_type:
+            existing_master_type = ""
+        opts.master_instance_type = existing_master_type
+        opts.instance_type = existing_slave_type
+        
         setup_cluster(conn, master_nodes, slave_nodes, opts, False)
 
     else:


### PR DESCRIPTION
As described in https://issues.apache.org/jira/browse/SPARK-6188 and discovered in https://issues.apache.org/jira/browse/SPARK-5838. 

When re-starting a cluster, if the user does not provide the instance types, which is the recommended behavior in the docs currently, the instance will be assigned the default type m1.large. This then affects the setup of the machines.

This solves this by getting the instance types from the existing instances, and overwriting the default options.